### PR TITLE
More preparation for Dwarf5

### DIFF
--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -279,11 +279,6 @@ public:
 	// Default lower bound for the current compilation unit. This depends on
 	// the language of the current unit.
 	unsigned currentDefaultLowerBound;
-
-	// Value of the DW_AT_low_pc attribute for the current compilation unit.
-	// Specify the default base address for use in location lists and range
-	// lists.
-	uint32_t currentBaseAddress;
 };
 
 #endif //__CV2PDB_H__

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -15,7 +15,6 @@
 
 #include <windows.h>
 #include <map>
-#include <unordered_map>
 
 extern "C" {
 	#include "mscvpdb.h"
@@ -172,17 +171,17 @@ public:
 	bool writeDWARFImage(const TCHAR* opath);
 
 	bool addDWARFSectionContrib(mspdb::Mod* mod, unsigned long pclo, unsigned long pchi);
-	bool addDWARFProc(DWARF_InfoData& id, DWARF_CompilationUnit* cu, DIECursor cursor);
-	int  addDWARFStructure(DWARF_InfoData& id, DWARF_CompilationUnit* cu, DIECursor cursor);
-	int  addDWARFFields(DWARF_InfoData& structid, DWARF_CompilationUnit* cu, DIECursor cursor, int off);
-	int  addDWARFArray(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu, DIECursor cursor);
+	bool addDWARFProc(DWARF_InfoData& id, DIECursor cursor);
+	int  addDWARFStructure(DWARF_InfoData& id, DIECursor cursor);
+	int  addDWARFFields(DWARF_InfoData& structid, DIECursor cursor, int off);
+	int  addDWARFArray(DWARF_InfoData& arrayid, DIECursor cursor);
 	int  addDWARFBasicType(const char*name, int encoding, int byte_size);
-	int  addDWARFEnum(DWARF_InfoData& enumid, DWARF_CompilationUnit* cu, DIECursor cursor);
-	int  getTypeByDWARFPtr(DWARF_CompilationUnit* cu, byte* ptr);
-	int  getDWARFTypeSize(DWARF_CompilationUnit* cu, byte* ptr);
-	void getDWARFArrayBounds(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu, DIECursor cursor,
+	int  addDWARFEnum(DWARF_InfoData& enumid, DIECursor cursor);
+	int  getTypeByDWARFPtr(byte* ptr);
+	int  getDWARFTypeSize(const DIECursor& parent, byte* ptr);
+	void getDWARFArrayBounds(DWARF_InfoData& arrayid, DIECursor cursor,
 		int& basetype, int& lowerBound, int& upperBound);
-	void getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, DWARF_CompilationUnit* cu,
+	void getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, const DIECursor& parent,
 		int& basetype, int& lowerBound, int& upperBound);
 	int getDWARFBasicType(int encoding, int byte_size);
 

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -559,10 +559,10 @@ public:
 	}
 };
 
-Location findBestFBLoc(const PEImage& img, unsigned long fblocoff)
+Location findBestFBLoc(const DIECursor& parent, unsigned long fblocoff)
 {
-	int regebp = img.isX64() ? 6 : 5;
-	LOCCursor cursor(img, fblocoff);
+	int regebp = parent.img->isX64() ? 6 : 5;
+	LOCCursor cursor(*parent.img, fblocoff);
 	LOCEntry entry;
 	Location longest = { Location::RegRel, DW_REG_CFA, 0 };
 	unsigned long longest_range = 0;
@@ -691,7 +691,7 @@ void CV2PDB::appendLexicalBlock(DWARF_InfoData& id, unsigned int proclo)
 	cbUdtSymbols += len;
 }
 
-bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIECursor cursor)
+bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DIECursor cursor)
 {
 	unsigned int pclo = procid.pclo - codeSegOff;
 	unsigned int pchi = procid.pchi - codeSegOff;
@@ -748,11 +748,11 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 
 	Location frameBase = decodeLocation(img, procid.frame_base, 0, DW_AT_frame_base);
 	if (frameBase.is_abs()) // pointer into location list in .debug_loc? assume CFA
-		frameBase = findBestFBLoc(img, frameBase.off);
+		frameBase = findBestFBLoc(cursor, frameBase.off);
 
     Location cfa = findBestCFA(img, cfi_index, procid.pclo, procid.pchi);
 
-	if (cu)
+	if (cursor.cu)
 	{
 		bool endarg = false;
 		DWARF_InfoData id;
@@ -765,10 +765,10 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 			{
 				if (id.location.type == ExprLoc || id.location.type == Block || id.location.type == SecOffset)
 				{
-					Location loc = id.location.type == SecOffset ? findBestFBLoc(img, id.location.sec_offset)
+					Location loc = id.location.type == SecOffset ? findBestFBLoc(cursor, id.location.sec_offset)
 					                                             : decodeLocation(img, id.location, &frameBase);
 					if (loc.is_regrel())
-						appendStackVar(id.name, getTypeByDWARFPtr(cu, id.type), loc, cfa);
+						appendStackVar(id.name, getTypeByDWARFPtr(id.type), loc, cfa);
 				}
 			}
 		}
@@ -836,10 +836,10 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 				{
 					if (id.name && (id.location.type == ExprLoc || id.location.type == Block))
 					{
-						Location loc = id.location.type == SecOffset ? findBestFBLoc(img, id.location.sec_offset)
+						Location loc = id.location.type == SecOffset ? findBestFBLoc(cursor, id.location.sec_offset)
 						                                             : decodeLocation(img, id.location, &frameBase);
 						if (loc.is_regrel())
-							appendStackVar(id.name, getTypeByDWARFPtr(cu, id.type), loc, cfa);
+							appendStackVar(id.name, getTypeByDWARFPtr(id.type), loc, cfa);
 					}
 				}
 				cursor.gotoSibling();
@@ -856,7 +856,7 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 	return true;
 }
 
-int CV2PDB::addDWARFFields(DWARF_InfoData& structid, DWARF_CompilationUnit* cu, DIECursor cursor, int baseoff)
+int CV2PDB::addDWARFFields(DWARF_InfoData& structid, DIECursor cursor, int baseoff)
 {
 	bool isunion = structid.tag == DW_TAG_union_type;
 	int nfields = 0;
@@ -887,20 +887,20 @@ int CV2PDB::addDWARFFields(DWARF_InfoData& structid, DWARF_CompilationUnit* cu, 
 				{
 					checkDWARFTypeAlloc(kMaxNameLen + 100);
 					codeview_fieldtype* dfieldtype = (codeview_fieldtype*)(dwarfTypes + cbDwarfTypes);
-					cbDwarfTypes += addFieldMember(dfieldtype, 0, baseoff + off, getTypeByDWARFPtr(cu, id.type), id.name);
+					cbDwarfTypes += addFieldMember(dfieldtype, 0, baseoff + off, getTypeByDWARFPtr(id.type), id.name);
 					nfields++;
 				}
 				else if (id.type)
 				{
 					// if it doesn't have a name, and it's a struct or union, embed it directly
-					DIECursor membercursor(cu, id.type);
+					DIECursor membercursor(cursor, id.type);
 					DWARF_InfoData memberid;
 					if (membercursor.readNext(memberid))
 					{
 						if (memberid.abstract_origin)
-							mergeAbstractOrigin(memberid, cu);
+							mergeAbstractOrigin(memberid, cursor);
 						if (memberid.specification)
-							mergeSpecification(memberid, cu);
+							mergeSpecification(memberid, cursor);
 
 						int cvtype = -1;
 						switch (memberid.tag)
@@ -908,7 +908,7 @@ int CV2PDB::addDWARFFields(DWARF_InfoData& structid, DWARF_CompilationUnit* cu, 
 						case DW_TAG_class_type:
 						case DW_TAG_structure_type:
 						case DW_TAG_union_type:
-							nfields += addDWARFFields(memberid, cu, membercursor, baseoff + off);
+							nfields += addDWARFFields(memberid, membercursor, baseoff + off);
 							break;
 						}
 					}
@@ -930,7 +930,7 @@ int CV2PDB::addDWARFFields(DWARF_InfoData& structid, DWARF_CompilationUnit* cu, 
 				codeview_fieldtype* bc = (codeview_fieldtype*)(dwarfTypes + cbDwarfTypes);
 				bc->bclass_v2.id = LF_BCLASS_V2;
 				bc->bclass_v2.offset = baseoff + off;
-				bc->bclass_v2.type = getTypeByDWARFPtr(cu, id.type);
+				bc->bclass_v2.type = getTypeByDWARFPtr(id.type);
 				bc->bclass_v2.attribute = 3; // public
 				cbDwarfTypes += sizeof(bc->bclass_v2);
 				for (; cbDwarfTypes & 3; cbDwarfTypes++)
@@ -943,13 +943,13 @@ int CV2PDB::addDWARFFields(DWARF_InfoData& structid, DWARF_CompilationUnit* cu, 
 	return nfields;
 }
 
-int CV2PDB::addDWARFStructure(DWARF_InfoData& structid, DWARF_CompilationUnit* cu, DIECursor cursor)
+int CV2PDB::addDWARFStructure(DWARF_InfoData& structid, DIECursor cursor)
 {
 	//printf("Adding struct %s, entryoff %d, abbrev %d\n", structid.name, structid.entryOff, structid.abbrev);
 
 	int fieldlistType = 0;
 	int nfields = 0;
-	if (cu)
+	if (cursor.cu)
 	{
 		checkDWARFTypeAlloc(100);
 		codeview_reftype* fl = (codeview_reftype*) (dwarfTypes + cbDwarfTypes);
@@ -971,7 +971,7 @@ int CV2PDB::addDWARFStructure(DWARF_InfoData& structid, DWARF_CompilationUnit* c
 			nfields++;
 		}
 #endif
-		nfields += addDWARFFields(structid, cu, cursor, 0);
+		nfields += addDWARFFields(structid, cursor, 0);
 		fl = (codeview_reftype*) (dwarfTypes + flbegin);
 		fl->fieldlist.len = cbDwarfTypes - flbegin - 2;
 		fieldlistType = nextDwarfType++;
@@ -991,19 +991,18 @@ int CV2PDB::addDWARFStructure(DWARF_InfoData& structid, DWARF_CompilationUnit* c
 	return cvtype;
 }
 
-void CV2PDB::getDWARFArrayBounds(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu,
-								DIECursor cursor, int& basetype, int& lowerBound, int& upperBound)
+void CV2PDB::getDWARFArrayBounds(DWARF_InfoData& arrayid, DIECursor cursor, int& basetype, int& lowerBound, int& upperBound)
 {
 	DWARF_InfoData id;
 
 	// TODO: handle multi-dimensional arrays
-	if (cu)
+	if (cursor.cu)
 	{
 		while (cursor.readNext(id, true))
 		{
 			if (id.tag == DW_TAG_subrange_type)
 			{
-				getDWARFSubrangeInfo(id, cu, basetype, lowerBound, upperBound);
+				getDWARFSubrangeInfo(id, cursor, basetype, lowerBound, upperBound);
 				return;
 			}
 			cursor.gotoSibling();
@@ -1011,10 +1010,10 @@ void CV2PDB::getDWARFArrayBounds(DWARF_InfoData& arrayid, DWARF_CompilationUnit*
 	}
 
 	// In case of error, return plausible defaults
-	getDWARFSubrangeInfo(id, NULL, basetype, lowerBound, upperBound);
+	getDWARFSubrangeInfo(id, cursor, basetype, lowerBound, upperBound);
 }
 
-void CV2PDB::getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, DWARF_CompilationUnit* cu,
+void CV2PDB::getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, const DIECursor& parent,
 	int& basetype, int& lowerBound, int& upperBound)
 {
 	// In case of error, return plausible defaults. Assume the array
@@ -1023,10 +1022,10 @@ void CV2PDB::getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, DWARF_CompilationU
 	lowerBound = currentDefaultLowerBound;
 	upperBound = lowerBound;
 
-	if (!cu || subrangeid.tag != DW_TAG_subrange_type)
+	if (!parent.cu || subrangeid.tag != DW_TAG_subrange_type)
 		return;
 
-	basetype = getTypeByDWARFPtr(cu, subrangeid.type);
+	basetype = getTypeByDWARFPtr(subrangeid.type);
 	if (subrangeid.has_lower_bound)
 		lowerBound = subrangeid.lower_bound;
 	upperBound = subrangeid.upper_bound;
@@ -1094,20 +1093,19 @@ int CV2PDB::getDWARFBasicType(int encoding, int byte_size)
 	return translateType(t);
 }
 
-int CV2PDB::addDWARFArray(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu,
-						  DIECursor cursor)
+int CV2PDB::addDWARFArray(DWARF_InfoData& arrayid, DIECursor cursor)
 {
 	int basetype, upperBound, lowerBound;
-	getDWARFArrayBounds(arrayid, cu, cursor, basetype, lowerBound, upperBound);
+	getDWARFArrayBounds(arrayid, cursor, basetype, lowerBound, upperBound);
 
 	checkUserTypeAlloc(kMaxNameLen + 100);
 	codeview_type* cvt = (codeview_type*) (userTypes + cbUserTypes);
 
 	cvt->array_v2.id = v3 ? LF_ARRAY_V3 : LF_ARRAY_V2;
-	cvt->array_v2.elemtype = getTypeByDWARFPtr(cu, arrayid.type);
+	cvt->array_v2.elemtype = getTypeByDWARFPtr(arrayid.type);
 	cvt->array_v2.idxtype = basetype;
 	int len = (BYTE*)&cvt->array_v2.arrlen - (BYTE*)cvt;
-	int size = (upperBound - lowerBound + 1) * getDWARFTypeSize(cu, arrayid.type);
+	int size = (upperBound - lowerBound + 1) * getDWARFTypeSize(cursor, arrayid.type);
 	len += write_numeric_leaf(size, &cvt->array_v2.arrlen);
 	((BYTE*)cvt)[len++] = 0; // empty name
 	for (; len & 3; len++)
@@ -1191,7 +1189,7 @@ int CV2PDB::addDWARFBasicType(const char*name, int encoding, int byte_size)
 	return cvtype;
 }
 
-int CV2PDB::addDWARFEnum(DWARF_InfoData& enumid, DWARF_CompilationUnit* cu, DIECursor cursor)
+int CV2PDB::addDWARFEnum(DWARF_InfoData& enumid, DIECursor cursor)
 {
 	/* Enumerated types are described in CodeView with two components:
 
@@ -1299,7 +1297,7 @@ int CV2PDB::addDWARFEnum(DWARF_InfoData& enumid, DWARF_CompilationUnit* cu, DIEC
 	/* Now the LF_FIELDLIST is ready, create the LF_ENUM type record itself. */
 	checkUserTypeAlloc();
 	int basetype = (enumid.type != 0)
-				   ? getTypeByDWARFPtr(cu, enumid.type)
+				   ? getTypeByDWARFPtr(enumid.type)
 				   : getDWARFBasicType(enumid.encoding, enumid.byte_size);
 	dtype = (codeview_type*)(userTypes + cbUserTypes);
 	const char* name = (enumid.name ? enumid.name : "__noname");
@@ -1310,7 +1308,7 @@ int CV2PDB::addDWARFEnum(DWARF_InfoData& enumid, DWARF_CompilationUnit* cu, DIEC
 	return enumType;
 }
 
-int CV2PDB::getTypeByDWARFPtr(DWARF_CompilationUnit* cu, byte* ptr)
+int CV2PDB::getTypeByDWARFPtr(byte* ptr)
 {
 	std::unordered_map<byte*, int>::iterator it = mapOffsetToType.find(ptr);
 	if(it == mapOffsetToType.end())
@@ -1318,10 +1316,10 @@ int CV2PDB::getTypeByDWARFPtr(DWARF_CompilationUnit* cu, byte* ptr)
 	return it->second;
 }
 
-int CV2PDB::getDWARFTypeSize(DWARF_CompilationUnit* cu, byte* typePtr)
+int CV2PDB::getDWARFTypeSize(const DIECursor& parent, byte* typePtr)
 {
 	DWARF_InfoData id;
-	DIECursor cursor(cu, typePtr);
+	DIECursor cursor(parent, typePtr);
 
 	if (!cursor.readNext(id))
 		return 0;
@@ -1334,16 +1332,16 @@ int CV2PDB::getDWARFTypeSize(DWARF_CompilationUnit* cu, byte* typePtr)
 		case DW_TAG_ptr_to_member_type:
 		case DW_TAG_reference_type:
 		case DW_TAG_pointer_type:
-			return cu->address_size;
+			return cursor.cu->address_size;
 		case DW_TAG_array_type:
 		{
 			int basetype, upperBound, lowerBound;
-			getDWARFArrayBounds(id, cu, cursor, basetype, lowerBound, upperBound);
-			return (upperBound - lowerBound + 1) * getDWARFTypeSize(cu, id.type);
+			getDWARFArrayBounds(id, cursor, basetype, lowerBound, upperBound);
+			return (upperBound - lowerBound + 1) * getDWARFTypeSize(cursor, id.type);
 		}
 		default:
 			if(id.type)
-				return getDWARFTypeSize(cu, id.type);
+				return getDWARFTypeSize(cursor, id.type);
 			break;
 	}
 	return 0;
@@ -1357,7 +1355,7 @@ bool CV2PDB::mapTypes()
 	{
 		DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)(img.debug_info.base + off);
 
-		DIECursor cursor(cu, (byte*)cu + sizeof(DWARF_CompilationUnit));
+		DIECursor cursor(cu, (byte*)cu + sizeof(*cu));
 		DWARF_InfoData id;
 		while (cursor.readNext(id))
 		{
@@ -1430,9 +1428,9 @@ bool CV2PDB::createTypes()
 						cursor.entryOff, cursor.level, id.code, id.tag);
 
 			if (id.abstract_origin)
-				mergeAbstractOrigin(id, cu);
+				mergeAbstractOrigin(id, cursor);
 			if (id.specification)
-				mergeSpecification(id, cu);
+				mergeSpecification(id, cursor);
 
 			int cvtype = -1;
 			switch (id.tag)
@@ -1441,36 +1439,36 @@ bool CV2PDB::createTypes()
 				cvtype = addDWARFBasicType(id.name, id.encoding, id.byte_size);
 				break;
 			case DW_TAG_typedef:
-				cvtype = appendModifierType(getTypeByDWARFPtr(cu, id.type), 0);
+				cvtype = appendModifierType(getTypeByDWARFPtr(id.type), 0);
 				addUdtSymbol(cvtype, id.name);
 				break;
 			case DW_TAG_pointer_type:
-				cvtype = appendPointerType(getTypeByDWARFPtr(cu, id.type), pointerAttr);
+				cvtype = appendPointerType(getTypeByDWARFPtr(id.type), pointerAttr);
 				break;
 			case DW_TAG_const_type:
-				cvtype = appendModifierType(getTypeByDWARFPtr(cu, id.type), 1);
+				cvtype = appendModifierType(getTypeByDWARFPtr(id.type), 1);
 				break;
 			case DW_TAG_reference_type:
-				cvtype = appendPointerType(getTypeByDWARFPtr(cu, id.type), pointerAttr | 0x20);
+				cvtype = appendPointerType(getTypeByDWARFPtr(id.type), pointerAttr | 0x20);
 				break;
 
 			case DW_TAG_subrange_type:
 				// It seems we cannot materialize bounds for scalar types in
 				// CodeView, so just redirect to a mere base type.
-				cvtype = appendModifierType(getTypeByDWARFPtr(cu, id.type), 0);
+				cvtype = appendModifierType(getTypeByDWARFPtr(id.type), 0);
 				break;
 
 			case DW_TAG_class_type:
 			case DW_TAG_structure_type:
 			case DW_TAG_union_type:
-				cvtype = addDWARFStructure(id, cu, cursor.getSubtreeCursor());
+				cvtype = addDWARFStructure(id, cursor.getSubtreeCursor());
 				break;
 			case DW_TAG_array_type:
-				cvtype = addDWARFArray(id, cu, cursor.getSubtreeCursor());
+				cvtype = addDWARFArray(id, cursor.getSubtreeCursor());
 				break;
 
 			case DW_TAG_enumeration_type:
-				cvtype = addDWARFEnum(id, cu, cursor.getSubtreeCursor());
+				cvtype = addDWARFEnum(id, cursor.getSubtreeCursor());
 				break;
 
 			case DW_TAG_subroutine_type:
@@ -1543,7 +1541,7 @@ bool CV2PDB::createTypes()
 					}
 
 					if (id.pclo && id.pchi)
-						addDWARFProc(id, cu, cursor.getSubtreeCursor());
+						addDWARFProc(id, cursor.getSubtreeCursor());
 				}
 				break;
 
@@ -1622,7 +1620,7 @@ bool CV2PDB::createTypes()
 					}
 					if (seg >= 0)
 					{
-						int type = getTypeByDWARFPtr(cu, id.type);
+						int type = getTypeByDWARFPtr(id.type);
 						if (dllimport)
 						{
 							checkDWARFTypeAlloc(100);

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -419,7 +419,7 @@ public:
 				attr.type = ExprLoc;
 				attr.expr.len = LEB128(ptr);
 				attr.expr.ptr = ptr;
-				cfa = decodeLocation(img, attr);
+				cfa = decodeLocation(attr);
 				ptr += attr.expr.len;
 				break;
 			}
@@ -458,7 +458,7 @@ public:
 				attr.type = Block;
 				attr.block.len = LEB128(ptr);
 				attr.block.ptr = ptr;
-				cfa = decodeLocation(img, attr); // TODO: push cfa on stack
+				cfa = decodeLocation(attr); // TODO: push cfa on stack
 				ptr += attr.expr.len;
 				break;
 			}
@@ -511,62 +511,14 @@ Location findBestCFA(const PEImage& img, const CFIIndex* index, unsigned int pcl
 	return ebp;
 }
 
-// Location list entry
-class LOCEntry
-{
-public:
-	byte* ptr;
-	unsigned long beg_offset;
-	unsigned long end_offset;
-	Location loc;
-
-	bool eol() const { return beg_offset == 0 && end_offset == 0; }
-};
-
-// Location list cursor
-class LOCCursor
-{
-public:
-	LOCCursor(const PEImage& image, unsigned long off)
-	: img (image)
-	, end((byte*)img.debug_loc.base + img.debug_loc.length)
-	, ptr((byte*)img.debug_loc.base + off)
-	{
-		default_address_size = img.isX64() ? 8 : 4;
-	}
-
-	const PEImage& img;
-	byte* end;
-	byte* ptr;
-	byte default_address_size;
-
-	bool readNext(LOCEntry& entry)
-	{
-		if(ptr >= end)
-			return false;
-		entry.beg_offset = (unsigned long) RDsize(ptr, default_address_size);
-		entry.end_offset = (unsigned long) RDsize(ptr, default_address_size);
-		if (entry.eol())
-			return true;
-
-		DWARF_Attribute attr;
-		attr.type = Block;
-		attr.block.len = RD2(ptr);
-		attr.block.ptr = ptr;
-		entry.loc = decodeLocation(img, attr);
-		ptr += attr.expr.len;
-		return true;
-	}
-};
-
 Location findBestFBLoc(const DIECursor& parent, unsigned long fblocoff)
 {
 	int regebp = parent.img->isX64() ? 6 : 5;
-	LOCCursor cursor(*parent.img, fblocoff);
+	LOCCursor cursor(parent, fblocoff);
 	LOCEntry entry;
 	Location longest = { Location::RegRel, DW_REG_CFA, 0 };
 	unsigned long longest_range = 0;
-	while(cursor.readNext(entry) && !entry.eol())
+	while(cursor.readNext(entry))
 	{
 		if(entry.loc.is_regrel() && entry.loc.reg == regebp)
 			return entry.loc;
@@ -746,7 +698,7 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DIECursor cursor)
 	addStackVar("local_var", 0x1001, 8);
 #endif
 
-	Location frameBase = decodeLocation(img, procid.frame_base, 0, DW_AT_frame_base);
+	Location frameBase = decodeLocation(procid.frame_base, 0, DW_AT_frame_base);
 	if (frameBase.is_abs()) // pointer into location list in .debug_loc? assume CFA
 		frameBase = findBestFBLoc(cursor, frameBase.off);
 
@@ -766,7 +718,7 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DIECursor cursor)
 				if (id.location.type == ExprLoc || id.location.type == Block || id.location.type == SecOffset)
 				{
 					Location loc = id.location.type == SecOffset ? findBestFBLoc(cursor, id.location.sec_offset)
-					                                             : decodeLocation(img, id.location, &frameBase);
+					                                             : decodeLocation(id.location, &frameBase);
 					if (loc.is_regrel())
 						appendStackVar(id.name, getTypeByDWARFPtr(id.type), loc, cfa);
 				}
@@ -796,28 +748,12 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DIECursor cursor)
 						id.pchi = 0;
 
 						// TODO: handle base address selection
-						byte *r = (byte *)img.debug_ranges.base + id.ranges;
-						byte *rend = (byte *)img.debug_ranges.base + img.debug_ranges.length;
-						while (r < rend)
+						RangeEntry range;
+						RangeCursor rangeCursor(cursor, id.ranges);
+						while (rangeCursor.readNext(range))
 						{
-							uint64_t pclo, pchi;
-
-							if (img.isX64())
-							{
-								pclo = RD8(r);
-								pchi = RD8(r);
-							}
-							else
-							{
-								pclo = RD4(r);
-								pchi = RD4(r);
-							}
-							if (pclo == 0 && pchi == 0)
-								break;
-							if (pclo >= pchi)
-								continue;
-							id.pclo = min(id.pclo, pclo + currentBaseAddress);
-							id.pchi = max(id.pchi, pchi + currentBaseAddress);
+							id.pclo = min(id.pclo, range.pclo);
+							id.pchi = max(id.pchi, range.pchi);
 						}
 					}
 
@@ -837,7 +773,7 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DIECursor cursor)
 					if (id.name && (id.location.type == ExprLoc || id.location.type == Block))
 					{
 						Location loc = id.location.type == SecOffset ? findBestFBLoc(cursor, id.location.sec_offset)
-						                                             : decodeLocation(img, id.location, &frameBase);
+						                                             : decodeLocation(id.location, &frameBase);
 						if (loc.is_regrel())
 							appendStackVar(id.name, getTypeByDWARFPtr(id.type), loc, cfa);
 					}
@@ -873,7 +809,7 @@ int CV2PDB::addDWARFFields(DWARF_InfoData& structid, DIECursor cursor, int baseo
 			int off = 0;
 			if (!isunion)
 			{
-				Location loc = decodeLocation(img, id.member_location, 0, DW_AT_data_member_location);
+				Location loc = decodeLocation(id.member_location, 0, DW_AT_data_member_location);
 				if (loc.is_abs())
 				{
 					off = loc.off;
@@ -918,7 +854,7 @@ int CV2PDB::addDWARFFields(DWARF_InfoData& structid, DIECursor cursor, int baseo
 		else if (id.tag == DW_TAG_inheritance)
 		{
 			int off = 0;
-			Location loc = decodeLocation(img, id.member_location, 0, DW_AT_data_member_location);
+			Location loc = decodeLocation(id.member_location, 0, DW_AT_data_member_location);
 			if (loc.is_abs())
 			{
 				cvid = S_CONSTANT_V2;
@@ -1353,9 +1289,12 @@ bool CV2PDB::mapTypes()
 	unsigned long off = 0;
 	while (off < img.debug_info.length)
 	{
-		DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)(img.debug_info.base + off);
+		DWARF_CompilationUnitInfo cu{};
+		byte* ptr = cu.read(img, &off);
+		if (!ptr)
+			continue;
 
-		DIECursor cursor(cu, (byte*)cu + sizeof(*cu));
+		DIECursor cursor(&cu, ptr);
 		DWARF_InfoData id;
 		while (cursor.readNext(id))
 		{
@@ -1393,8 +1332,6 @@ bool CV2PDB::mapTypes()
 					typeID++;
 			}
 		}
-
-		off += sizeof(cu->unit_length) + cu->unit_length;
 	}
 
 	if (debug & DbgBasic)
@@ -1417,9 +1354,12 @@ bool CV2PDB::createTypes()
 	unsigned long off = 0;
 	while (off < img.debug_info.length)
 	{
-		DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)(img.debug_info.base + off);
+		DWARF_CompilationUnitInfo cu{};
+		byte* ptr = cu.read(img, &off);
+		if (!ptr)
+			continue;
 
-		DIECursor cursor(cu, (byte*)cu + sizeof(DWARF_CompilationUnit));
+		DIECursor cursor(&cu, ptr);
 		DWARF_InfoData id;
 		while (cursor.readNext(id))
 		{
@@ -1505,28 +1445,13 @@ bool CV2PDB::createTypes()
 						else if (id.ranges != ~0)
 						{
 							entry_point = ~0;
-							byte* r = (byte*)img.debug_ranges.base + id.ranges;
-							byte* rend = (byte*)img.debug_ranges.base + img.debug_ranges.length;
-							while (r < rend)
+							RangeEntry range;
+							RangeCursor rangeCursor(cursor, id.ranges);
+							while (rangeCursor.readNext(range))
 							{
-								uint64_t pclo, pchi;
-
-								if (img.isX64())
-								{
-									pclo = RD8(r);
-									pchi = RD8(r);
-								}
-								else
-								{
-									pclo = RD4(r);
-									pchi = RD4(r);
-								}
-								if (pclo == 0 && pchi == 0)
-									break;
-								if (pclo >= pchi)
-									continue;
-								entry_point = min(entry_point, pclo + currentBaseAddress);
+								entry_point = min(entry_point, range.pclo);
 							}
+
 							if (entry_point == ~0)
 								entry_point = 0;
 						}
@@ -1546,7 +1471,8 @@ bool CV2PDB::createTypes()
 				break;
 
 			case DW_TAG_compile_unit:
-				currentBaseAddress = id.pclo;
+				// Set the implicit base address for range lists.
+				cu.base_address = id.pclo;
 				switch (id.language)
 				{
 				case DW_LANG_Ada83:
@@ -1570,22 +1496,24 @@ bool CV2PDB::createTypes()
 				{
 					if (id.ranges > 0 && id.ranges < img.debug_ranges.length)
 					{
-						unsigned char* r = (unsigned char*)img.debug_ranges.base + id.ranges;
-						unsigned char* rend = (unsigned char*)img.debug_ranges.base + img.debug_ranges.length;
-						while (r < rend)
+						RangeEntry range;
+						RangeCursor rangeCursor(cursor, id.ranges);
+						while (rangeCursor.readNext(range))
 						{
-							unsigned long pclo = RD4(r);
-							unsigned long pchi = RD4(r);
-							if (pclo == 0 && pchi == 0)
-								break;
-							//printf("%s %s %x - %x\n", dir, name, pclo, pchi);
-							if (!addDWARFSectionContrib(mod, pclo, pchi))
+							if (debug & DbgPdbContrib)
+								fprintf(stderr, "%s:%d: Adding a section contrib: %I64x-%I64x\n", __FUNCTION__, __LINE__,
+										range.pclo, range.pchi);
+
+							if (!addDWARFSectionContrib(mod, range.pclo, range.pchi))
 								return false;
 						}
 					}
 					else
 					{
-						//printf("%s %s %x - %x\n", dir, name, pclo, pchi);
+						if (debug & DbgPdbContrib)
+							fprintf(stderr, "%s:%d: Adding a section contrib: %x-%x\n", __FUNCTION__, __LINE__,
+									id.pclo, id.pchi);
+
 						if (!addDWARFSectionContrib(mod, id.pclo, id.pchi))
 							return false;
 					}
@@ -1609,7 +1537,7 @@ bool CV2PDB::createTypes()
 					}
 					else
 					{
-						Location loc = decodeLocation(img, id.location);
+						Location loc = decodeLocation(id.location);
 						if (loc.is_abs())
 						{
 							segOff = loc.off;
@@ -1648,8 +1576,6 @@ bool CV2PDB::createTypes()
 				assert(mapOffsetToType[id.entryPtr] == cvtype);
 			}
 		}
-
-		off += sizeof(cu->unit_length) + cu->unit_length;
 	}
 
 	return true;

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -17,10 +17,12 @@ enum DebugLevel : unsigned {
 	DbgPdbTypes = 0x2,
 	DbgPdbSyms = 0x4,
 	DbgPdbLines = 0x8,
-	DbgDwarfTagRead = 0x10,
-	DbgDwarfAttrRead = 0x20,
-	DbgDwarfLocLists = 0x40,
-	DbgDwarfLines = 0x80
+	DbgPdbContrib = 0x10,
+	DbgDwarfTagRead = 0x100,
+	DbgDwarfAttrRead = 0x200,
+	DbgDwarfLocLists = 0x400,
+	DbgDwarfRangeLists = 0x800,
+	DbgDwarfLines = 0x1000
 };
 
 DEFINE_ENUM_FLAG_OPERATORS(DebugLevel);
@@ -57,7 +59,7 @@ inline int SLEB128(byte* &p)
 	return x;
 }
 
-inline unsigned int RD2(byte* &p)
+inline unsigned short RD2(byte* &p)
 {
 	unsigned int x = *p++;
 	x |= *p++ << 8;
@@ -122,17 +124,28 @@ struct DWARF_Attribute
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "pshpack1.h"
-
-struct DWARF_CompilationUnit
+struct DWARF_CompilationUnitInfo
 {
-	unsigned int unit_length; // 12 byte in DWARF-64
+	uint32_t unit_length; // 12 byte in DWARF-64
 	unsigned short version;
-	unsigned int debug_abbrev_offset; // 8 byte in DWARF-64
 	byte address_size;
+	byte unit_type;
+	unsigned int debug_abbrev_offset; // 8 byte in DWARF-64
 
-	bool isDWARF64() const { return unit_length == ~0; }
-	int refSize() const { return unit_length == ~0 ? 8 : 4; }
+	// Value of the DW_AT_low_pc attribute for the current compilation unit.
+	// Specify the default base address for use in location lists and range
+	// lists.
+	uint32_t base_address;
+
+	// Offset within the debug_info section
+	uint32_t cu_offset;
+
+	bool is_dwarf64;
+
+	byte* read(const PEImage& img, unsigned long *off);
+
+	bool isDWARF64() const { return is_dwarf64; }
+	int refSize() const { return isDWARF64() ? 8 : 4; }
 };
 
 struct DWARF_FileName
@@ -260,6 +273,8 @@ struct DWARF_TypeForm
 	unsigned int type, form;
 };
 
+#include "pshpack1.h"
+
 struct DWARF_LineNumberProgramHeader
 {
 	unsigned int unit_length; // 12 byte in DWARF-64
@@ -309,6 +324,8 @@ struct DWARF2_LineNumberProgramHeader
 	// string include_directories[] // zero byte terminated
 	// DWARF_FileNames file_names[] // zero byte terminated
 };
+
+#include "poppack.h"
 
 struct DWARF_LineState
 {
@@ -372,7 +389,6 @@ struct DWARF_LineState
 	}
 };
 
-#include "poppack.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -398,13 +414,64 @@ struct Location
 	bool is_regrel() const { return type == RegRel; }
 };
 
-typedef std::unordered_map<std::pair<unsigned, unsigned>, byte*> abbrevMap_t;
+// Location list entry
+class LOCEntry
+{
+public:
+	byte* ptr;
+	unsigned long beg_offset;
+	unsigned long end_offset;
+	Location loc;
 
+	bool eol() const { return beg_offset == 0 && end_offset == 0; }
+};
+
+// Location list cursor
+class LOCCursor
+{
+public:
+	LOCCursor(const DIECursor& parent, unsigned long off);
+
+	const DIECursor& parent;
+	byte* end;
+	byte* ptr;
+
+	bool readNext(LOCEntry& entry);
+};
+
+// Range list entry
+class RangeEntry
+{
+public:
+	uint64_t pclo;
+	uint64_t pchi;
+
+	void addBase(uint64_t base)
+	{
+		pclo += base;
+		pchi += base;
+	}
+};
+
+// Range list cursor
+class RangeCursor
+{
+public:
+	RangeCursor(const DIECursor& parent, unsigned long off);
+
+	const DIECursor& parent;
+	byte *end;
+	byte *ptr;
+
+	bool readNext(RangeEntry& entry);
+};
+
+typedef std::unordered_map<std::pair<unsigned, unsigned>, byte*> abbrevMap_t;
 
 // Attempts to partially evaluate DWARF location expressions.
 // The only supported expressions are those, whose result may be represented
 // as either an absolute value, a register, or a register-relative address.
-Location decodeLocation(const PEImage& img, const DWARF_Attribute& attr, const Location* frameBase = 0, int at = 0);
+Location decodeLocation(const DWARF_Attribute& attr, const Location* frameBase = 0, int at = 0);
 
 void mergeAbstractOrigin(DWARF_InfoData& id, const DIECursor& parent);
 void mergeSpecification(DWARF_InfoData& id, const DIECursor& parent);
@@ -413,7 +480,7 @@ void mergeSpecification(DWARF_InfoData& id, const DIECursor& parent);
 class DIECursor
 {
 public:
-	DWARF_CompilationUnit* cu;
+	DWARF_CompilationUnitInfo* cu;
 	byte* ptr;
 	unsigned int entryOff;
 	int level;
@@ -431,7 +498,7 @@ public:
 	static void setContext(PEImage* img_, DebugLevel debug_);
 
 	// Create a new DIECursor
-	DIECursor(DWARF_CompilationUnit* cu_, byte* ptr);
+	DIECursor(DWARF_CompilationUnitInfo* cu_, byte* ptr);
 
 	// Create a child DIECursor
 	DIECursor(const DIECursor& parent, byte* ptr_);


### PR DESCRIPTION
The theme of this PR is to carry contextual information needed for dwarf decoding with the DIECursor. 

We also move LocationList decoding fully into readDwarf.cpp and create a parallel iterator for RangeList decoding.

Finally, to prepare for reading dwarf5, we read the compilation unit header using byte-by-byte reads rather than by casting to a structure. We also put contextual information with the compilation unit info.

See the individual commits for more information. This pull request should be merged rather than squashed.